### PR TITLE
Fix "thirdy" typo in table of contents

### DIFF
--- a/app/controllers/guides_controller.rb
+++ b/app/controllers/guides_controller.rb
@@ -20,7 +20,7 @@ class GuidesController < ApplicationController
     {
       title: 'Recipies',
       pages: [
-        { title: "Using thirdy party CSS", path: "/recipies/using-third-party-css" }
+        { title: "Using third party CSS", path: "/recipies/using-third-party-css" }
       ]
     },
       title: 'Reference',


### PR DESCRIPTION
I noticed a slight typo in the table of contents for mint-lang.com. I believe the intended word here was "third".