### PR TITLE
Fix Linux install instructions

### DIFF
--- a/app/views/landings/install.haml
+++ b/app/views/landings/install.haml
@@ -59,7 +59,7 @@
           %code.plaintext
             wget --no-verbose -O mint https://mint-lang.s3-eu-west-1.amazonaws.com/mint-latest-linux
             chmod +x ./mint
-            sudo mv /mint /usr/local/bin/mint
+            sudo mv ./mint /usr/local/bin/mint
 
     .install__section.install__section--with-margin
       .install__title


### PR DESCRIPTION
I noticed a small issue with the install instructions for Mint on Linux. The `mv` command should move `./mint` to the bin folder, but it currently suggests moving from `/mint` instead.