### PR TITLE
Add test help output to cli guide

### DIFF
--- a/app/views/guides/pages/getting-started/using-the-cli.haml
+++ b/app/views/guides/pages/getting-started/using-the-cli.haml
@@ -115,6 +115,35 @@
   %li open a browser in headless mode
   %li run the tests in the browser printing the results along the way
 
+%p
+  The test command contains several flags you can set, such as which browser to use:
+
+%pre
+  %code.plaintext
+    :plain
+      mint test --help
+      Usage:
+        mint test [flags...] <test> [arg...]
+
+      Runs the tests
+
+      Flags:
+        --browser, -b (default: "chrome")  # Which browser to run the tests in
+        --env, -e (default: "")            # Loads the given .env file
+        --help                             # Displays help for the current command.
+        --manual, -m                       # Start the test server for manual testing
+        --reporter, -r (default: "dot")    # Which reporter to use (dot, documentation)
+
+      Arguments:
+        test
+
+%p
+  Currently both
+  %code chrome
+  and 
+  %code firefox
+  are supported.
+
 %h2 Building for production
 
 %p


### PR DESCRIPTION
This would prevent such problems as I ran into
with https://github.com/mint-lang/mint/issues/168.

Fixes https://github.com/mint-lang/mint/issues/171.