### PR TITLE
Fix mistake in sequence docs

### DIFF
--- a/app/views/guides/pages/reference/control-expressions/sequence.haml
+++ b/app/views/guides/pages/reference/control-expressions/sequence.haml
@@ -56,7 +56,7 @@
         store it in the "users" variable
         */
         users =
-          decode response.body as Array(User)
+          decode body as Array(User)
 
         /* If everything went well store the users */
         next { users = users }


### PR DESCRIPTION
Fixes a small mistake where `body` was never used in the sequence code example.