### PR TITLE
Fix return type definition in anonymous function

### DIFF
--- a/app/views/guides/pages/reference/functions.haml
+++ b/app/views/guides/pages/reference/functions.haml
@@ -201,7 +201,7 @@
     :escaped
       component Greeter {
         fun render : Html {
-          <div onClick={(event : Html.Event) : Void { Debug.log("Hello") }}>
+          <div onClick={(event : Html.Event) : String { Debug.log("Hello") }}>
             "Click Me!"
           </div>
         }


### PR DESCRIPTION
The example in the docs doesn't seem to compile, I think the signature just needs to be changed from a `Void` type to `String` (as `Debug.log` as a type of  `Function(a,a)`)