### PR TITLE
Add a note about installing CLT on OSX

### DIFF
--- a/app/views/landings/install.haml
+++ b/app/views/landings/install.haml
@@ -18,6 +18,9 @@
 
         %pre.install__snippet
           %code.plaintext
+            # For MacOSX, ensure XCode's CLT is installed to prevent building llvm from source
+            xcode-select --install
+            
             brew tap homebrew-community/alpha
             brew install mint-lang
 


### PR DESCRIPTION
See https://github.com/mint-lang/mint/issues/218#issuecomment-619222681

Essentially on OSX if you don't have XCode's command line toolkit installed then `brew install mint-lang` will require building `llvm` from source which takes _hours_. An extremely frustrating experience for people just wanting to give the language a spin. 