### PR TITLE
Update VSCode Extension Link

### DIFF
--- a/app/views/guides/pages/getting-started/tools.haml
+++ b/app/views/guides/pages/getting-started/tools.haml
@@ -9,7 +9,7 @@
 
 %ul
   %li
-    %a(href="https://github.com/faustinoaq/vscode-mint-lang")
+    %a(href="https://github.com/s0kil/mint-vscode")
       VSCode extension
     \- adds syntax highlighting and autocomplete support
 


### PR DESCRIPTION
The currently linked VSCode mint extension is no longer maintained. I have updated the link to an actively maintained version of this extension.