### PR TITLE
Update Homebrew install

### DIFF
--- a/app/views/landings/install.haml
+++ b/app/views/landings/install.haml
@@ -21,7 +21,7 @@
             \# For MacOSX, ensure XCode's CLT is installed to prevent building llvm from source
             xcode-select --install
 
-            brew tap homebrew-community/alpha
+            brew tap homebrew-community/mint
             brew install mint-lang
 
     .install__section.install__section--with-margin


### PR DESCRIPTION
Use [`homebrew-community/mint`](https://github.com/homebrew-community/homebrew-mint) as `homebrew-community/alpha` is now deprecated