### PR TITLE
Fix typos in macOS and Xcode

### DIFF
--- a/app/views/landings/install.haml
+++ b/app/views/landings/install.haml
@@ -8,17 +8,17 @@
     .install__section
       .install__title
         = render partial: 'icons/apple'
-        %span Install on Mac OSX (or Linux)
+        %span Install on macOS (or Linux)
 
       .install__instructions
-        To easily install Mint on MacOSX or Linux you can use
+        To easily install Mint on macOS or Linux you can use
 
         = succeed '.' do
           %a(href="http://brew.sh/" target="_blank" rel="noreferer") Homebrew
 
         %pre.install__snippet
           %code.plaintext
-            \# For MacOSX, ensure XCode's CLT is installed to prevent building llvm from source
+            \# For macOS, ensure Xcode's CLT is installed to prevent building llvm from source
             xcode-select --install
             \# If you have installed mint before
             brew untap homebrew-community/mint
@@ -56,7 +56,7 @@
 
       .install__instructions
         %p
-          Since Mint is just a binary you can download the pre build binaries
+          Since Mint is just a binary you can download the pre-built binaries
           and use them.
 
         %pre.install__snippet
@@ -72,7 +72,7 @@
 
       .install__instructions
         %p
-          You can run mint using a docker container by using the
+          You can run mint using a Docker container by using the
           %a(href="https://github.com/mint-lang/mint-docker")
             mint-docker
           repository.


### PR DESCRIPTION
‘macOS’ and ‘Xcode’ is the proper term and capitalisation.