### PR TITLE
toc wrapper height fix

### DIFF
--- a/app/assets/stylesheets/_toc.scss
+++ b/app/assets/stylesheets/_toc.scss
@@ -8,7 +8,6 @@
     box-sizing: border-box;
     padding-right: 50px;
     margin-right: 50px;
-    height: 100vh;
   }
 
   &__spacer {


### PR DESCRIPTION
Remove fixed height on toc__wrapper so footer won't overlap.