### PR TITLE
Add single-letter variable warning in JS inlining

### DIFF
--- a/app/views/guides/pages/reference/javascript-interop/inlining.haml
+++ b/app/views/guides/pages/reference/javascript-interop/inlining.haml
@@ -113,6 +113,16 @@
         }
       }
 
+%p.hint.hint--warning
+  = octicon "alert"
+  %span
+    Generated interpolation code uses single-letter argument names like
+    %code n
+    and
+    %code i
+    , which can cause issues with shadowing or order of operations. To be safe,
+    avoid using single-letter variable names in your JavaScript code.
+
 %h2 Specifying the type
 
 %p

--- a/app/views/guides/pages/reference/javascript-interop/inlining.haml
+++ b/app/views/guides/pages/reference/javascript-interop/inlining.haml
@@ -116,12 +116,14 @@
 %p.hint.hint--warning
   = octicon "alert"
   %span
-    Generated interpolation code uses single-letter argument names like
-    %code n
-    and
+    Generated interpolation code uses argument names like
     %code i
+    and
+    %code xyz
     , which can cause issues with shadowing or order of operations. To be safe,
-    avoid using single-letter variable names in your JavaScript code.
+    prefix your JavaScript variable names with a dollar sign, like
+    %code $i
+    \.
 
 %h2 Specifying the type
 


### PR DESCRIPTION
Adds a warning to the interop inlining page about using single-letter variables in JavaScript inlining, to help others avoid getting bitten by https://github.com/mint-lang/mint/issues/452