### PR TITLE
Fix code issue in `encode` expression example

### DIFF
--- a/app/views/guides/pages/reference/javascript-interop/encode-expression.haml
+++ b/app/views/guides/pages/reference/javascript-interop/encode-expression.haml
@@ -41,7 +41,7 @@
 %pre
   %code
     :escaped
-      encode { name = "Bob" }
+      (encode { name = "Bob" })
       |> Json.stringify()
 
       /* { "name": "Bob"} */


### PR DESCRIPTION
Wrap `(encode { name = "Bob" })` in parentheses so the example code will work.