### PR TITLE
Fix `case` code example with enums not compiling

### DIFF
--- a/app/views/guides/pages/reference/control-expressions/case.haml
+++ b/app/views/guides/pages/reference/control-expressions/case.haml
@@ -54,8 +54,8 @@
   %code
     :escaped
       case (result) {
-        Result::Err error => /* do something with the error */
-        Result::Ok value => /* do something with the value */
+        Result::Err(error) => /* do something with the error */
+        Result::Ok(value) => /* do something with the value */
       }
 
 %h2 Matching a Tuple


### PR DESCRIPTION
The example code on the case page would not compile without the parentheses. 