### PR TITLE
Added guide page on HTTP requests

### DIFF
--- a/app/views/guides/pages/reference/HTTP-requests.haml
+++ b/app/views/guides/pages/reference/HTTP-requests.haml
@@ -1,0 +1,36 @@
+- set_meta_tags title: 'Guide / Reference / HTTP requests'
+
+%h1 HTTP requests
+
+%p
+  The
+  %code Http
+  module contains functions to make and send HTTP requests.
+
+%p
+  Here is an example of a GET request to the
+  %a(href="https://pipedream.com/apps/swapi")
+    Star Wars API
+  to fetch planets:
+
+%pre
+  %code
+    :escaped
+      response =
+        "https://swapi.dev/api/planets"
+        |> Http.get()
+        |> Http.send()
+
+      object =
+        response.body
+        |> Json.parse()
+        |> Maybe.toResult("")
+
+      decodedResults =
+        decode object as Data
+
+%p
+  To see the full code for this example, check out
+  %a(href="/blog/handling-http-requests")
+    this blog post
+  on HTTP requests.


### PR DESCRIPTION
I took the example code from [this blog post](https://www.mint-lang.com/blog/handling-http-requests) to start a guide page on creating HTTP requests. I haven't used requests in Mint much yet, so someone with more experience could probably add much more useful info here, but it took me a while to find the blog post when I wanted to learn about how to use requests in Mint, so I thought having even a small guide page on this topic might be a good start.